### PR TITLE
Fixes CXX** compiler selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,15 @@ curl -O http://r.research.att.com/libs/clang-4.0.0-darwin15.6-Release.tar.gz
 tar fvxz clang-4.0.0-darwin15.6-Release.tar.gz -C /
 
 # Overwrites ~/.R/Makevars file if present otherwise creates it
-cat <<- \EOF > ~/.R/Makevars
+cat <<- EOF > ~/.R/Makevars
 # The following statements are required to use the clang4 binary
 CC=/usr/local/clang4/bin/clang
 CXX=/usr/local/clang4/bin/clang++
-CXX1X=$CXX
-CXX98=$CXX
-CXX11=$CXX
-CXX14=$CXX
-CXX17=$CXX
+CXX1X=/usr/local/clang4/bin/clang++
+CXX98=/usr/local/clang4/bin/clang++
+CXX11=/usr/local/clang4/bin/clang++
+CXX14=/usr/local/clang4/bin/clang++
+CXX17=/usr/local/clang4/bin/clang++
 LDFLAGS=-L/usr/local/clang4/lib
 # End clang4 inclusion statements
 EOF
@@ -71,7 +71,7 @@ To verify the installer's SHA256 hash use:
 
 ```bash
 openssl sha -sha256 ~/Downloads/clang4-r.pkg
-## SHA256(clang4-r.pkg)= 5349cc3830dd28c03e364adc6772d2638627d90a113c47ef78a60edb3ddab264
+## SHA256(clang4-r.pkg)= 8b48e3229415d2a564f84345430a0f600e5f7e6d05b51139d4dcd860f1cc029f
 ```
 
 ## Overview of Files

--- a/distribution.xml
+++ b/distribution.xml
@@ -11,7 +11,7 @@
     <choice id="com.rbinaries.clang4" visible="false">
         <pkg-ref id="com.rbinaries.clang4"/>
     </choice>
-    <pkg-ref id="com.rbinaries.clang4" version="1.1.0" onConclusion="none">clang4-r-temp.pkg</pkg-ref>
+    <pkg-ref id="com.rbinaries.clang4" version="1.2.0" onConclusion="none">clang4-r-temp.pkg</pkg-ref>
 	<title>clang4 R Binary</title>
 	<background file="Rlogo.png" mime-type="image/png" />
 	<welcome file="WELCOME_DISPLAY.rtf"/>

--- a/make_installer.sh
+++ b/make_installer.sh
@@ -35,7 +35,7 @@ fi
 chmod a+x scripts/*
 
 # Version of installer
-INSTALLER_VERSION=1.1.0
+INSTALLER_VERSION=1.2.0
 
 # Build macOS installer
 pkgbuild --root ROOT \

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -75,6 +75,12 @@ add_config_variable(){
 # Local User Makevars file
 R_MAKEVARS_LOCAL=~/.R/Makevars
 
+# Location of CC Compiler
+CC_COMPILER=/usr/local/clang4/bin/clang
+
+# Location of CXX Compiler
+CXX_COMPILER=/usr/local/clang4/bin/clang++
+
 echo "Checking if file '~/.R/Makevars' exists"
 if [ -f "$R_MAKEVARS_LOCAL" ]; then	
 
@@ -83,19 +89,19 @@ if [ -f "$R_MAKEVARS_LOCAL" ]; then
 	# Consider adding [[:space:]]*= for a more selective destruction
 	
 	remove_config_variable "CC" $R_MAKEVARS_LOCAL
-	add_config_variable "CC=/usr/local/clang4/bin/clang" $R_MAKEVARS_LOCAL
+	add_config_variable "CC=$CC_COMPILER" $R_MAKEVARS_LOCAL
 	
 	remove_config_variable "CXX" $R_MAKEVARS_LOCAL
-	add_config_variable "CXX=/usr/local/clang4/bin/clang++" $R_MAKEVARS_LOCAL
+	add_config_variable "CXX=$CXX_COMPILER" $R_MAKEVARS_LOCAL
     
     # Adds configuration variables that specify all C++ standards
     
-    add_config_variable 'CXX1X=$CXX' $R_MAKEVARS_LOCAL
+    add_config_variable "CXX1X=$CXX_COMPILER" $R_MAKEVARS_LOCAL
     
-    add_config_variable 'CXX98=$CXX' $R_MAKEVARS_LOCAL
-    add_config_variable 'CXX11=$CXX' $R_MAKEVARS_LOCAL
-    add_config_variable 'CXX14=$CXX' $R_MAKEVARS_LOCAL
-    add_config_variable 'CXX17=$CXX' $R_MAKEVARS_LOCAL
+    add_config_variable "CXX98=$CXX_COMPILER" $R_MAKEVARS_LOCAL
+    add_config_variable "CXX11=$CXX_COMPILER" $R_MAKEVARS_LOCAL
+    add_config_variable "CXX14=$CXX_COMPILER" $R_MAKEVARS_LOCAL
+    add_config_variable "CXX17=$CXX_COMPILER" $R_MAKEVARS_LOCAL
 
 	# Remove any instances of the LDFLAG (in the odd case they re-run the installer...)
 	LDFLAGS_PATH_VAR="-L/usr/local/clang4/lib"
@@ -118,16 +124,16 @@ else
 	echo "Filling '~/.R/Makevars' with appropriate compile time implicit variables..."
 	
 	# Fill with appropriate linking statements via heredoc insertion
-	# The - removes tabbing and \ prevents the $CXX variable from being executed
-	cat <<- \EOF > $R_MAKEVARS_LOCAL
+	# The - removes tabbing
+	cat <<- EOF > $R_MAKEVARS_LOCAL
 	# The following statements are required to use the clang4 binary
-	CC=/usr/local/clang4/bin/clang
-	CXX=/usr/local/clang4/bin/clang++
-	CXX1X=$CXX
-	CXX98=$CXX
-	CXX11=$CXX
-	CXX14=$CXX
-	CXX17=$CXX
+	CC=$CC_COMPILER
+	CXX=$CXX_COMPILER
+	CXX1X=$CXX_COMPILER
+	CXX98=$CXX_COMPILER
+	CXX11=$CXX_COMPILER
+	CXX14=$CXX_COMPILER
+	CXX17=$CXX_COMPILER
 	LDFLAGS=-L/usr/local/clang4/lib
 	# End clang4 inclusion statements
 EOF


### PR DESCRIPTION
Previously, referencing the $CXX variable for CXX** standards in ~/.R/Makevars would cause:

/bin/sh: XX: command not found
make: *** [file91e37f2852ce.o] Error 127
XX -std=gnu++11

Changing it to $(CXX) yielded:

/Users/your_username/.R/Makevars:6: *** Recursive variable `CXX' references itself (eventually).  Stop.

So, we go back to linking directly and filing a bug report...